### PR TITLE
Enable wireless card if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ where:
 
 ### Settings
 
-By default, the access point's SSID is the hostname of the machine that runs the script and the passphrase is based on the Raspberry Pi's serial number. This allows for repeatable network credentials between sessions, making it easy for clients to connect to their local device even if the OS has been reset. The configuration of the network created by the access point is read from `defaults.conf`.
+By default, the access point's SSID is the hostname of the machine that runs the script. If the machine is a Raspberry Pi, the default passphrase is based in the device's serial number; otherwise it defaults to `12345678`. This allows for repeatable network credentials between sessions, making it easy for clients to connect to their local device even if the OS has been reset. The configuration of the network created by the access point is read from `defaults.conf`.
 
 ### Steps
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ where:
     status : display access point state and information.
 ```
 
-# Default Behaviour
+## Default Behaviour
 
-## Settings
+### Settings
 
 By default, the access point's SSID is the hostname of the machine that runs the script and the passphrase is based on the Raspberry Pi's serial number. This allows for repeatable network credentials between sessions, making it easy for clients to connect to their local device even if the OS has been reset. The configuration of the network created by the access point is read from `defaults.conf`.
 
-## Steps
+### Steps
 
-### Start
+#### Start
 
 * Enable wireless interface via `rfkill` if necessary
 * Create a virtual network interface to be used by the access point
@@ -33,14 +33,14 @@ By default, the access point's SSID is the hostname of the machine that runs the
 * Start access point service through `hostapd`
 * Restart networking services
 
-### Stop
+#### Stop
 
 * Stop `hostapd` access point service
 * Restore patched networking configuration files
 * Remove virtual network interface
 * Restart networking services
 
-# Station Mode: Things To Note
+## Station Mode: Things To Note
 
 Even though the wireless interface is enabled, you may still need to configure it for it to work with `wpa_supplicant`. For example, in Raspberry Pi OS and derivatives you'll need to select your country during onboarding or set it manually using raspi-config.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ where:
 
 By default, the SSID is the hostname of the machine that runs the script, and the default password is set based on the Raspberry Pi serial number. The configuration of the network created by the access point is read from `defaults.conf`.
 
+When the Access Point starts, it will verify that the wireless interface is enabled and enable it if necessary. Note that even though the card is enabled, you still need to configure it for it to work on Station mode with `wpa_supplicant`. For example, in Raspberry Pi OS and derivatives you'll need to select your country during onboarding or set it manually using `raspi-config`.
+
 ## AP Customization
 
 The access point network configuration can be customized by editing `defaults.conf` (located in `/etc/default/wifi-ap-sta/defaults.conf`); for example, setting up a different IP address for the network, the range of addresses that the DHCP server can lease, and the network SSID and passphrase.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,32 @@ where:
     status : display access point state and information.
 ```
 
-## Default Behaviour
+# Default Behaviour
 
-By default, the SSID is the hostname of the machine that runs the script, and the default password is set based on the Raspberry Pi serial number. The configuration of the network created by the access point is read from `defaults.conf`.
+## Settings
 
-When the Access Point starts, it will verify that the wireless interface is enabled and enable it if necessary. Note that even though the card is enabled, you still need to configure it for it to work on Station mode with `wpa_supplicant`. For example, in Raspberry Pi OS and derivatives you'll need to select your country during onboarding or set it manually using `raspi-config`.
+By default, the access point's SSID is the hostname of the machine that runs the script and the passphrase is based on the Raspberry Pi's serial number. This allows for repeatable network credentials between sessions, making it easy for clients to connect to their local device even if the OS has been reset. The configuration of the network created by the access point is read from `defaults.conf`.
+
+## Steps
+
+### Start
+
+* Enable wireless interface via `rfkill` if necessary
+* Create a virtual network interface to be used by the access point
+* Patch system network configuration files
+* Start access point service through `hostapd`
+* Restart networking services
+
+### Stop
+
+* Stop `hostapd` access point service
+* Restore patched networking configuration files
+* Remove virtual network interface
+* Restart networking services
+
+# Station Mode: Things To Note
+
+Even though the wireless interface is enabled, you may still need to configure it for it to work with `wpa_supplicant`. For example, in Raspberry Pi OS and derivatives you'll need to select your country during onboarding or set it manually using raspi-config.
 
 ## AP Customization
 

--- a/src/wifi-ap-sta
+++ b/src/wifi-ap-sta
@@ -64,6 +64,14 @@ clean_config_files() {
 	sed -i 's|INTERFACESv4="'"${access_point_interface}"'"|INTERFACESv4=""|' /etc/default/isc-dhcp-server
 }
 
+enable_wireless_card_if_necessary() {
+	wifi_state=$(rfkill list wifi -o Soft -n)
+	if [[ "${wifi_state}" == "blocked" ]]; then
+		echo "Wireless card is disabled - enabling ..."
+		rfkill unblock wifi
+	fi
+}
+
 patch_config_files() {
 	hostapd_conf="/etc/hostapd/hostapd.conf"
 	if [[ -f "${hostapd_conf}" ]]; then
@@ -237,6 +245,7 @@ if [[ -z "${wpa_passphrase}" ]]; then
 fi
 
 if [[ "${command}" == "start" ]]; then
+	enable_wireless_card_if_necessary
 	stop_ap_mode_if_active
 	create_virtual_interface
 	patch_config_files


### PR DESCRIPTION
Closes #9 

The wireless card is disabled by default on first boot, causing AP mode to fail to start.

```
$ rfkill list all
0: phy0: Wireless LAN
	Soft blocked: yes
	Hard blocked: no
1: hci0: Bluetooth
	Soft blocked: no
	Hard blocked: no
```

The changes included in this PR will check if the wireless card is enabled before starting AP mode, and enable it if necessary.

