### PR TITLE
Create AP password only on 'configure' or 'start' commands

### DIFF
--- a/wifi-ap-sta
+++ b/wifi-ap-sta
@@ -401,11 +401,9 @@ _wait_for_virtual_interface() {
 }
 
 _wait_for_virtual_interface_ip_addr() {
-	iface="$(hostapd_cli get_config | head -n1 | awk '{print $NF}' | tr -d "'")"
-
-	if [[ -z "$(ip -f inet addr show "${iface}" | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')" ]]; then
-		echo "Interface '${iface}' does not yet have an IP address - waiting..."
-		while [[ -z "$(ip -f inet addr show "${iface}" | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')" ]]; do
+	if [[ -z "$(ip -f inet addr show "${AP_IFACE}" | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')" ]]; then
+		echo "Interface '${AP_IFACE}' does not yet have an IP address - waiting..."
+		while [[ -z "$(ip -f inet addr show "${AP_IFACE}" | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')" ]]; do
 			sleep 1
 		done
 	fi

--- a/wifi-ap-sta
+++ b/wifi-ap-sta
@@ -95,6 +95,7 @@ fi
 [[ -f "${AP_MODE_CONFIG_FILE}" ]] && source "${AP_MODE_CONFIG_FILE}"
 
 initialise_ap_values
+
 main() {
 	if [[ "${command}" == "configure" ]]; then
 		do_configure
@@ -109,9 +110,10 @@ main() {
 		do_disable
 	elif [[ "${command}" == "wait_interface" ]]; then
 		do_wait_interface
-	elif [[ "${command}" == "status" ]]; then
-		print_current_status
+	else
+		:
 	fi
+	print_current_status
 }
 
 do_configure() {

--- a/wifi-ap-sta
+++ b/wifi-ap-sta
@@ -99,6 +99,7 @@ initialise_ap_values
 main() {
 	if [[ "${command}" == "configure" ]]; then
 		do_configure
+		exit
 	elif [[ "${command}" == "start" ]]; then
 		do_start
 	elif [[ "${command}" == "stop" ]]; then
@@ -109,6 +110,7 @@ main() {
 		do_disable
 	elif [[ "${command}" == "wait_interface" ]]; then
 		do_wait_interface
+		exit
 	else
 		:
 	fi

--- a/wifi-ap-sta
+++ b/wifi-ap-sta
@@ -101,7 +101,6 @@ main() {
 		do_configure
 	elif [[ "${command}" == "start" ]]; then
 		do_start
-		print_current_status
 	elif [[ "${command}" == "stop" ]]; then
 		do_stop
 	elif [[ "${command}" == "enable" ]]; then

--- a/wifi-ap-sta
+++ b/wifi-ap-sta
@@ -16,9 +16,12 @@ wifi_country() {
 	echo "${country:-00}"
 }
 
-initialise_ap_values() {
+initialise_ap_ssid_and_password() {
 	AP_SSID="${AP_SSID:-$(produce_ssid)}"
 	AP_PASSWORD="${AP_PASSWORD:-$(produce_password)}"
+}
+
+initialise_ap_values() {
 	AP_IFACE="${AP_IFACE:-wlan_ap0}"
 	AP_MAC="${AP_MAC:-99:88:77:66:55:44}"
 	WIFI_IFACE="${WIFI_IFACE:-wlan0}"
@@ -92,12 +95,12 @@ fi
 [[ -f "${AP_MODE_CONFIG_FILE}" ]] && source "${AP_MODE_CONFIG_FILE}"
 
 initialise_ap_values
-
 main() {
 	if [[ "${command}" == "configure" ]]; then
 		do_configure
 	elif [[ "${command}" == "start" ]]; then
 		do_start
+		print_current_status
 	elif [[ "${command}" == "stop" ]]; then
 		do_stop
 	elif [[ "${command}" == "enable" ]]; then
@@ -106,13 +109,13 @@ main() {
 		do_disable
 	elif [[ "${command}" == "wait_interface" ]]; then
 		do_wait_interface
-	else
-		:
+	elif [[ "${command}" == "status" ]]; then
+		print_current_status
 	fi
-	print_current_status
 }
 
 do_configure() {
+	initialise_ap_ssid_and_password
 	_patch_config_files
 }
 


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-14) |


#### Main changes

Password is now created or read only when running `wifi-ap-sta configure` or `wifi-ap-sta start`, where it's actually needed for AP to work. This means that `wifi-ap-sta enable` will not create a password.

Also, added some exit clauses to the `configure` and `wait_interface` commands, to avoid printing out the status of AP mode. This was added because these commands use `hostapd_cli` to run, which is available later in the boot process and would fail to run otherwise.

#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
- Install artifacts into your pi-top[4].
- Make sure to remove any existing configuration and stop/disable mode:
```
sudo wifi-ap-sta stop
sudo wifi-ap-sta disable
sudo rm /etc/default/wifi-ap-sta || true
sudo rm /etc/hostapd/hostapd.conf || true
```
- Enable AP mode with `sudo wifi-ap-sta enable`
- Make sure there's no AP configuration file: `cat /etc/default/wifi-ap-sta` should report that the file doesn't exist.
- Reboot your pi-top and make sure that AP mode still works using the new credentials the app created on boot.

#### Tag anyone who definitely needs to review or help
-
