### PR TITLE
Restart isc-dhcp-server on 'stop' command

### DIFF
--- a/wifi-ap-sta
+++ b/wifi-ap-sta
@@ -461,7 +461,7 @@ _start_wifi_managed_mode() {
 	if systemctl status pt-dhcp-server &>/dev/null; then
 		_restart_and_wait_for_service_state pt-dhcp-server exited
 	else
-		systemctl stop isc-dhcp-server
+		_restart_and_wait_for_service_state isc-dhcp-server running
 	fi
 	_restart_and_wait_for_service_state dhcpcd running
 	_restart_and_wait_for_service_state wpa_supplicant running


### PR DESCRIPTION
Fixes issues when running `stop` command; the service `isc-dhcp-server` also manages connections through the USB interface so it can't be stopped. This caused connectivity issues when stopping AP mode through `pt-miniscreen` and then trying to connect though USB, since no IP addresses are leased.