### PR TITLE
Don't persist network pass-through configuration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,11 +13,10 @@ Depends:
  ${misc:Depends},
  dhcpcd5,
  hostapd,
- iptables-persistent,
+ iptables,
  isc-dhcp-server,
 # 'ifconfig' command
  net-tools,
- netfilter-persistent,
  systemd,
  udev,
  wpasupplicant,

--- a/wifi-ap-sta
+++ b/wifi-ap-sta
@@ -336,24 +336,12 @@ fi"
 
 _enable_wireless_network_passthrough() {
 	echo 1 > /proc/sys/net/ipv4/ip_forward
-
-	_configure_file \
-		/etc/sysctl.d/routed-ap.conf \
-		"Enable IPv4 routing from different networks" \
-		"net.ipv4.ip_forward=1"
-
 	iptables -t nat -A POSTROUTING -o "${WIFI_IFACE}" -j MASQUERADE
-
-	# Persist configuration on next boot
-	netfilter-persistent save
 }
 
 _disable_wireless_network_passthrough() {
 	echo 0 > /proc/sys/net/ipv4/ip_forward
-
-	_delete_config_file_modifications "${package_name}" "/etc/sysctl.d/routed-ap.conf"
-
-	rm -f /etc/iptables/rules.v4
+	iptables -t nat -D POSTROUTING -o "${WIFI_IFACE}" -j MASQUERADE
 }
 
 ############################


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-94) |


#### Main changes
- Don't persist network pass-through config since it's added everytime `isc-dhcp-server.service` starts.
- Use `iptables` directly to remove internal network routing when disabling AP mode.
- Remove `iptables-persistent` and `netfilter-persistent` dependencies.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
